### PR TITLE
Add website title and reminder of edge case

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -8,6 +8,7 @@
       name="description"
       content="Web site created using create-react-app"
     />
+    <title>Password Generator</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/src/components/result.tsx
+++ b/src/components/result.tsx
@@ -13,6 +13,10 @@ export default function Result(props: Props) {
   const { password, reminder, setReminder } = props
 
   const copyTextToClipboard = async () => {
+    if (password === "") {
+      setReminder({ status: "isValid", text: "No password generated yet." })
+      return
+    }
     if ("clipboard" in navigator) {
       try {
         await navigator.clipboard.writeText(password)


### PR DESCRIPTION
### Description
- Add website title.
- Add a reminder of the edge case.
### Test plan
- [x] The copy icon remains and the reminder shows when there is no password generated but the user clicks the copy icon.  
 